### PR TITLE
Use ImGui::TextUnformatted instead of ImGui::Text where it's not needed

### DIFF
--- a/src/game/scene/scene.cpp
+++ b/src/game/scene/scene.cpp
@@ -300,10 +300,10 @@ void SceneBase::updateImgui()
             if (showFPS)
             {
                 ImGui::PushID("##fps");
-                ImGui::Text((boost::format("FPS: Render %d | Input %d | Update %d")
-                    % State::get(IndexNumber::FPS)
-                    % State::get(IndexNumber::INPUT_DETECT_FPS)
-                    % State::get(IndexNumber::SCENE_UPDATE_FPS)).str().c_str());
+                ImGui::Text("FPS: Render %d | Input %d | Update %d",
+                    State::get(IndexNumber::FPS),
+                    State::get(IndexNumber::INPUT_DETECT_FPS),
+                    State::get(IndexNumber::SCENE_UPDATE_FPS));
                 ImGui::PopID();
             }
 
@@ -321,7 +321,7 @@ void SceneBase::updateImgui()
                 if (!State::get(idx).empty())
                 {
                     ImGui::PushID(overlayTextID[count++]);
-                    ImGui::Text(State::get(idx).c_str());
+                    ImGui::TextUnformatted(State::get(idx).c_str());
                     ImGui::PopID();
                 }
             }

--- a/src/game/scene/scene_play_imgui.cpp
+++ b/src/game/scene/scene_play_imgui.cpp
@@ -59,14 +59,14 @@ void ScenePlay::imguiAdjustMenu()
                 ImGui::TableSetupColumn("##slider", ImGuiTableColumnFlags_WidthStretch);
 
                 ImGui::TableNextColumn();
-                ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_1P_X));
+                ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_1P_X));
                 ImGui::TableNextColumn();
                 ImGui::SliderInt("##judge1px", &s->adjustPlayJudgePosition1PX, -imguiAdjustBorderX, imguiAdjustBorderX);
                 ImGui::SameLine();
                 if (ImGui::Button(" R ##judge1pxreset")) s->adjustPlayJudgePosition1PX = 0;
 
                 ImGui::TableNextColumn();
-                ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_1P_Y));
+                ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_1P_Y));
                 ImGui::TableNextColumn();
                 ImGui::SliderInt("##judge1py", &s->adjustPlayJudgePosition1PY, imguiAdjustBorderY, -imguiAdjustBorderY);
                 ImGui::SameLine();
@@ -75,14 +75,14 @@ void ScenePlay::imguiAdjustMenu()
                 if (imguiAdjustHas2P)
                 {
                     ImGui::TableNextColumn();
-                    ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_2P_X));
+                    ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_2P_X));
                     ImGui::TableNextColumn();
                     ImGui::SliderInt("##judge2px", &s->adjustPlayJudgePosition2PX, -imguiAdjustBorderX, imguiAdjustBorderX);
                     ImGui::SameLine();
                     if (ImGui::Button(" R ##judge2pxreset")) s->adjustPlayJudgePosition2PX = 0;
 
                     ImGui::TableNextColumn();
-                    ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_2P_Y));
+                    ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_JUDGE_POS_2P_Y));
                     ImGui::TableNextColumn();
                     ImGui::SliderInt("##judge2py", &s->adjustPlayJudgePosition2PY, imguiAdjustBorderY, -imguiAdjustBorderY);
                     ImGui::SameLine();
@@ -93,28 +93,28 @@ void ScenePlay::imguiAdjustMenu()
 
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
-                ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_X));
+                ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_X));
                 ImGui::TableNextColumn();
                 ImGui::SliderInt("##note1px", &s->adjustPlayNote1PX, -imguiAdjustBorderX, imguiAdjustBorderX);
                 ImGui::SameLine();
                 if (ImGui::Button(" R ##note1pxreset")) s->adjustPlayNote1PX = 0;
 
                 ImGui::TableNextColumn();
-                ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_Y));
+                ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_Y));
                 ImGui::TableNextColumn();
                 ImGui::SliderInt("##note1py", &s->adjustPlayNote1PY, imguiAdjustBorderY, -imguiAdjustBorderY);
                 ImGui::SameLine();
                 if (ImGui::Button(" R ##note1pyreset")) s->adjustPlayNote1PY = 0;
 
                 ImGui::TableNextColumn();
-                ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_W));
+                ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_W));
                 ImGui::TableNextColumn();
                 ImGui::SliderInt("##note1pw", &s->adjustPlayNote1PW, -imguiAdjustBorderSize, imguiAdjustBorderSize);
                 ImGui::SameLine();
                 if (ImGui::Button(" R ##note1pwreset")) s->adjustPlayNote1PW = 0;
 
                 ImGui::TableNextColumn();
-                ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_H));
+                ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_1P_H));
                 ImGui::TableNextColumn();
                 ImGui::SliderInt("##note1ph", &s->adjustPlayNote1PH, -imguiAdjustBorderSize, imguiAdjustBorderSize);
                 ImGui::SameLine();
@@ -123,28 +123,28 @@ void ScenePlay::imguiAdjustMenu()
                 if (imguiAdjustHas2P)
                 {
                     ImGui::TableNextColumn();
-                    ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_X));
+                    ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_X));
                     ImGui::TableNextColumn();
                     ImGui::SliderInt("##note2px", &s->adjustPlayNote2PX, -imguiAdjustBorderX, imguiAdjustBorderX);
                     ImGui::SameLine();
                     if (ImGui::Button(" R ##note2pxreset")) s->adjustPlayNote2PX = 0;
 
                     ImGui::TableNextColumn();
-                    ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_Y));
+                    ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_Y));
                     ImGui::TableNextColumn();
                     ImGui::SliderInt("##note2py", &s->adjustPlayNote2PY, imguiAdjustBorderY, -imguiAdjustBorderY);
                     ImGui::SameLine();
                     if (ImGui::Button(" R ##note2pyreset")) s->adjustPlayNote2PY = 0;
 
                     ImGui::TableNextColumn();
-                    ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_W));
+                    ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_W));
                     ImGui::TableNextColumn();
                     ImGui::SliderInt("##note2pw", &s->adjustPlayNote2PW, -imguiAdjustBorderSize, imguiAdjustBorderSize);
                     ImGui::SameLine();
                     if (ImGui::Button(" R ##jnote2pwreset")) s->adjustPlayNote2PW = 0;
 
                     ImGui::TableNextColumn();
-                    ImGui::Text(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_H));
+                    ImGui::TextUnformatted(i18n::c(PLAY_SKIN_ADJUST_NOTE_2P_H));
                     ImGui::TableNextColumn();
                     ImGui::SliderInt("##note2ph", &s->adjustPlayNote2PH, -imguiAdjustBorderSize, imguiAdjustBorderSize);
                     ImGui::SameLine();

--- a/src/game/scene/scene_pre_select.cpp
+++ b/src/game/scene/scene_pre_select.cpp
@@ -446,8 +446,8 @@ void ScenePreSelect::updateImgui()
     ImGui::SetNextWindowSize(ImVec2(ConfigMgr::get('V', cfg::V_DISPLAY_RES_X, CANVAS_WIDTH), ConfigMgr::get('V', cfg::V_DISPLAY_RES_Y, CANVAS_HEIGHT)), ImGuiCond_Always);
     if (ImGui::Begin("LoadSong", NULL, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoCollapse))
     {
-        ImGui::Text(textHint.c_str());
-        ImGui::Text(textHint2.c_str());
+        ImGui::TextUnformatted(textHint.c_str());
+        ImGui::TextUnformatted(textHint2.c_str());
 
         ImGui::End();
     }

--- a/src/game/scene/scene_select_imgui.cpp
+++ b/src/game/scene/scene_select_imgui.cpp
@@ -295,7 +295,7 @@ void SceneSelect::imguiSettings()
                     int old_imgui_add_profile_popup_error = imgui_add_profile_popup_error;
                     bool ok = false;
 
-                    ImGui::Text(i18n::c(NEW_PROFILE_NAME));
+                    ImGui::TextUnformatted(i18n::c(NEW_PROFILE_NAME));
                     ImGui::SameLine();
                     ok |= ImGui::InputText("##newprofilename", imgui_add_profile_buf, sizeof(imgui_add_profile_buf), ImGuiInputTextFlags_EnterReturnsTrue);
                     ImGui::SameLine();
@@ -353,7 +353,7 @@ void SceneSelect::imguiSettings()
                         if (errorMessage.empty())
                             errorMessage = (boost::format(i18n::c(NEW_PROFILE_DUPLICATE)) % imgui_add_profile_buf).str();
                     }
-                    ImGui::TextColored({ 1.f, 0.2f, 0.2f, 1.f }, errorMessage.c_str());
+                    ImGui::TextColored({ 1.f, 0.2f, 0.2f, 1.f }, "%s", errorMessage.c_str());
 
                     ImGui::EndPopup();
                 }
@@ -544,7 +544,7 @@ void SceneSelect::imguiPageOptionsGeneral()
 
     if (ImGui::BeginChild("##pagesub11"))
     {
-        ImGui::Text(i18n::c(PROFILE));
+        ImGui::TextUnformatted(i18n::c(PROFILE));
         ImGui::SameLine(infoRowWidth);
         ImGui::Combo("##profile", &imgui_profile_index, imgui_profiles_display.data(), (int)imgui_profiles_display.size());
 
@@ -558,7 +558,7 @@ void SceneSelect::imguiPageOptionsGeneral()
 
         /////////////////////////////////////////////////////////////////////////////////////////
 
-        ImGui::Text(i18n::c(PLAYER_NAME));
+        ImGui::TextUnformatted(i18n::c(PLAYER_NAME));
         ImGui::SameLine(infoRowWidth);
         bool modifiedPlayName = false;
         modifiedPlayName |= ImGui::InputText("##playername", imgui_player_name_buf, sizeof(imgui_player_name_buf), ImGuiInputTextFlags_EnterReturnsTrue);
@@ -569,13 +569,13 @@ void SceneSelect::imguiPageOptionsGeneral()
             imguiApplyPlayerName();
         }
 
-        ImGui::Text(i18n::c(LANGUAGE));
+        ImGui::TextUnformatted(i18n::c(LANGUAGE));
         ImGui::SameLine(infoRowWidth);
         ImGui::Combo("##language", &imgui_language_index, imgui_languages_display.data(), (int)imgui_languages_display.size());
 
         /////////////////////////////////////////////////////////////////////////////////////////
 
-        ImGui::Text(i18n::c(LOG_LEVEL));
+        ImGui::TextUnformatted(i18n::c(LOG_LEVEL));
         ImGui::SameLine(infoRowWidth);
         static const char* imgui_log_level_display[] =
         {
@@ -600,14 +600,14 @@ void SceneSelect::imguiPageOptionsJukebox()
 
     if (ImGui::BeginChild("##pagesub12"))
     {
-        ImGui::Text(i18n::c(JUKEBOX_REFRESH_HINT));
+        ImGui::TextUnformatted(i18n::c(JUKEBOX_REFRESH_HINT));
 
         ImGui::Spacing();
         ImGui::Separator();
 
         /////////////////////////////////////////////////////////////////////////////////////////
 
-        ImGui::Text(i18n::c(JUKEBOX_FOLDER));
+        ImGui::TextUnformatted(i18n::c(JUKEBOX_FOLDER));
         {
             bool enterPath = ImGui::InputTextWithHint("##folderpath", i18n::c(JUKEBOX_FOLDER_PATH_HINT), imgui_folder_path_buf, sizeof(imgui_folder_path_buf), ImGuiInputTextFlags_EnterReturnsTrue);
             if (enterPath || (ImGui::SameLine(), ImGui::Button(" + ##folder")))
@@ -639,7 +639,7 @@ void SceneSelect::imguiPageOptionsJukebox()
 
         /////////////////////////////////////////////////////////////////////////////////////////
 
-        ImGui::Text(i18n::c(JUKEBOX_TABLES));
+        ImGui::TextUnformatted(i18n::c(JUKEBOX_TABLES));
         {
             bool enterUrl = ImGui::InputTextWithHint("##tableurl", i18n::c(JUKEBOX_TABLE_URL_HINT), imgui_table_url_buf, sizeof(imgui_table_url_buf), ImGuiInputTextFlags_EnterReturnsTrue);
             if (enterUrl || (ImGui::SameLine(), ImGui::Button(" + ##table")))
@@ -665,11 +665,11 @@ void SceneSelect::imguiPageOptionsVideo()
 
     if (ImGui::BeginChild("##pagesub13"))
     {
-        ImGui::Text(i18n::c(VIDEO_RESOLUTION));
+        ImGui::TextUnformatted(i18n::c(VIDEO_RESOLUTION));
         ImGui::SameLine(infoRowWidth);
         ImGui::Combo("##resolution", &imgui_video_display_resolution_index, imgui_video_display_resolution_display.data(), (int)imgui_video_display_resolution_display.size());
 
-        ImGui::Text(i18n::c(VIDEO_SS_LEVEL));
+        ImGui::TextUnformatted(i18n::c(VIDEO_SS_LEVEL));
         ImGui::SameLine(infoRowWidth);
         static const char* imgui_video_ss_display[] =
         {
@@ -685,7 +685,7 @@ void SceneSelect::imguiPageOptionsVideo()
         ImGui::SameLine();
         HelpMarker(i18n::c(VIDEO_SS_LEVEL_HINT));
 
-        ImGui::Text(i18n::c(VIDEO_SCREEN_MODE));
+        ImGui::TextUnformatted(i18n::c(VIDEO_SCREEN_MODE));
         ImGui::SameLine(infoRowWidth);
         const char* imgui_video_mode_display[] =
         {
@@ -698,7 +698,7 @@ void SceneSelect::imguiPageOptionsVideo()
             imguiRefreshVideoDisplayResolutionList();
         }
 
-        ImGui::Text(i18n::c(VIDEO_VSYNC));
+        ImGui::TextUnformatted(i18n::c(VIDEO_VSYNC));
         ImGui::SameLine(infoRowWidth);
         const char* imgui_vsync_mode_display[] =
         {
@@ -711,7 +711,7 @@ void SceneSelect::imguiPageOptionsVideo()
         };
         ImGui::Combo("##vsync", &imgui_video_vsync_index, imgui_vsync_mode_display, sizeof(imgui_vsync_mode_display) / sizeof(char*));
 
-        ImGui::Text(i18n::c(VIDEO_MAXFPS));
+        ImGui::TextUnformatted(i18n::c(VIDEO_MAXFPS));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt("##maxfps", &imgui_video_maxFPS, 0);
 
@@ -739,7 +739,7 @@ void SceneSelect::imguiPageOptionsAudio()
 
     if (ImGui::BeginChild("##pagesub14"))
     {
-        ImGui::Text(i18n::c(AUDIO_DEVICE));
+        ImGui::TextUnformatted(i18n::c(AUDIO_DEVICE));
         ImGui::SameLine(infoRowWidth);
         ImGui::Combo("##audiodevice", &imgui_audio_device_index, imgui_audio_devices_display.data(), (int)imgui_audio_devices_display.size());
 
@@ -750,11 +750,11 @@ void SceneSelect::imguiPageOptionsAudio()
 
         ImGui::Spacing();
 
-        ImGui::Text(i18n::c(AUDIO_BUFFER_COUNT));
+        ImGui::TextUnformatted(i18n::c(AUDIO_BUFFER_COUNT));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt("##bufcount", &imgui_audio_bufferCount, 0);
 
-        ImGui::Text(i18n::c(AUDIO_BUFFER_LENGTH));
+        ImGui::TextUnformatted(i18n::c(AUDIO_BUFFER_LENGTH));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt("##bufsize", &imgui_audio_bufferSize, 0);
 
@@ -773,18 +773,18 @@ void SceneSelect::imguiPageOptionsPlay()
 
     if (ImGui::BeginChild("##pagesub15"))
     {
-        ImGui::Text(i18n::c(MISS_BGA_TIME));
+        ImGui::TextUnformatted(i18n::c(MISS_BGA_TIME));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt("##misstime", &imgui_adv_missBGATime, 0);
 
-        ImGui::Text(i18n::c(MIN_INPUT_INTERVAL));
+        ImGui::TextUnformatted(i18n::c(MIN_INPUT_INTERVAL));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt("##mininputinterval", &imgui_adv_minInputInterval, 1, 10);
         ImGui::SameLine();
         HelpMarker(i18n::c(MIN_INPUT_INTERVAL_HINT));
         //ImGui::Checkbox("Accept mouse movements as Analog input", &imgui_adv_mouseAnalog);
 
-        ImGui::Text(i18n::c(INPUT_POLLING_RATE));
+        ImGui::TextUnformatted(i18n::c(INPUT_POLLING_RATE));
         ImGui::SameLine(infoRowWidth);
         static const char* imgui_play_inputPollingRate_display[] =
         {
@@ -815,7 +815,7 @@ void SceneSelect::imguiPageOptionsPlay()
         HelpMarker(i18n::c(INPUT_POLLING_RATE_WARNING_WINDOWS));
 #endif
 
-        ImGui::Text(i18n::c(DEFAULT_TARGET));
+        ImGui::TextUnformatted(i18n::c(DEFAULT_TARGET));
         ImGui::SameLine(infoRowWidth);
         imgui_play_defaultTarget = State::get(IndexNumber::DEFAULT_TARGET_RATE);
         if (ImGui::SliderInt("##defaulttarget", &imgui_play_defaultTarget, 0, 100, "%d %%", ImGuiSliderFlags_None))
@@ -823,7 +823,7 @@ void SceneSelect::imguiPageOptionsPlay()
             State::set(IndexNumber::DEFAULT_TARGET_RATE, std::clamp(imgui_play_defaultTarget, 0, 100));
         }
 
-        ImGui::Text(i18n::c(JUDGE_TIMING));
+        ImGui::TextUnformatted(i18n::c(JUDGE_TIMING));
         ImGui::SameLine(infoRowWidth);
         imgui_play_judgeTiming = State::get(IndexNumber::TIMING_ADJUST_VISUAL);
         if (ImGui::SliderInt("##judgetiming", &imgui_play_judgeTiming, -99, 99, "%d ms", ImGuiSliderFlags_None))
@@ -845,7 +845,7 @@ void SceneSelect::imguiPageOptionsPlay()
         }
 
         ImGui::BeginDisabled(imgui_play_lockGreenNumber);
-        ImGui::Text(i18n::c(HISPEED));
+        ImGui::TextUnformatted(i18n::c(HISPEED));
         ImGui::SameLine(infoRowWidth);
         imgui_play_hispeed = gPlayContext.playerState[PLAYER_SLOT_PLAYER].hispeed;
         if (ImGui::SliderFloat("##hispeed", &imgui_play_hispeed, 0.01f, 10.0f, "%.02f", ImGuiSliderFlags_None))
@@ -857,7 +857,7 @@ void SceneSelect::imguiPageOptionsPlay()
         ImGui::EndDisabled();
 
         ImGui::BeginDisabled(!imgui_play_lockGreenNumber);
-        ImGui::Text(i18n::c(GREENNUMBER));
+        ImGui::TextUnformatted(i18n::c(GREENNUMBER));
         ImGui::SameLine(infoRowWidth);
         imgui_play_greenNumber = State::get(IndexNumber::GREEN_NUMBER_1P);
         if (ImGui::SliderInt("##greennumber", &imgui_play_greenNumber, 1, 1200, "%d", ImGuiSliderFlags_None))
@@ -907,19 +907,19 @@ void SceneSelect::imguiPageOptionsSelect()
 
     if (ImGui::BeginChild("##pagesub16"))
     {
-        ImGui::Text(i18n::c(SCROLL_SPEED));
+        ImGui::TextUnformatted(i18n::c(SCROLL_SPEED));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt2("##adv1", imgui_adv_scrollSpeed);
         ImGui::SameLine();
         HelpMarker(i18n::c(SCROLL_SPEED_HINT));
 
-        ImGui::Text(i18n::c(NEW_SONG_DURATION));
+        ImGui::TextUnformatted(i18n::c(NEW_SONG_DURATION));
         ImGui::SameLine(infoRowWidth);
         ImGui::InputInt("##adv2", &imgui_adv_newSongDuration, 1, 10);
         ImGui::SameLine();
         HelpMarker(i18n::c(NEW_SONG_DURATION_HINT));
 
-        ImGui::Text(i18n::c(SELECT_KEYBINDINGS));
+        ImGui::TextUnformatted(i18n::c(SELECT_KEYBINDINGS));
         ImGui::SameLine(infoRowWidth);
         static const char* imgui_adv_select_keybindings_display[] =
         {
@@ -1661,7 +1661,7 @@ bool SceneSelect::imguiArenaJoinLobbyPrompt()
             ImGui::SetNextWindowSize(ImVec2(480.f, 180.f), ImGuiCond_Always);
             if (ImGui::BeginPopupModal("JOIN LOBBY", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize))
             {
-                ImGui::Text("IP Address");
+                ImGui::TextUnformatted("IP Address");
                 ImGui::SameLine();
                 if (ImGui::IsWindowAppearing())
                     ImGui::SetKeyboardFocusHere();


### PR DESCRIPTION
Fixes unintended formatting.
In turn this fixes garbage data being shown in options in the name of "Target RATE" option (fixes #35).